### PR TITLE
Issue 1 - add GH actions and enable docker compose CI

### DIFF
--- a/.env-40
+++ b/.env-40
@@ -1,0 +1,8 @@
+# docker images
+MW_VERSION?=1.40
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mariadb:11.2"
+
+# extensions
+SMW_VERSION?=dev-master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.39'
-            smw_version: 4.2.0
+            smw_version: 4.2. # required only for JSONScript testing
             php_version: 8.1
             database_type: mysql
             database_image: "mysql:8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.39'
-            smw_version: 4.2. # required only for JSONScript testing
+            smw_version: 4.2.0  # required only for JSONScript testing
             php_version: 8.1
             database_type: mysql
             database_image: "mysql:8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,6 @@ jobs:
       - name: Upload code coverage
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/php/coverage.xml
         if: matrix.coverage == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
             database_image: "mariadb:11.2"
             coverage: false
             experimental: false
+          - mediawiki_version: '1.42'
+            smw_version: dev-master
+            php_version: 8.2
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
+            experimental: true
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
-            coverage: false
+            coverage: true
             experimental: false
           - mediawiki_version: '1.42'
             smw_version: dev-master
@@ -43,7 +43,6 @@ jobs:
       MW_VERSION: ${{ matrix.mediawiki_version }}
       SMW_VERSION: ${{ matrix.smw_version }}
       PHP_VERSION: ${{ matrix.php_version }}
-      AL_VERSION: ${{ matrix.al_version }}
       DB_TYPE: ${{ matrix.database_type }}
       DB_IMAGE: ${{ matrix.database_image }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+
+  test:
+
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      matrix:
+        include:
+          - mediawiki_version: '1.39'
+            smw_version: 4.2.0
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.40'
+            smw_version: dev-master
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
+            experimental: false
+
+    env:
+      MW_VERSION: ${{ matrix.mediawiki_version }}
+      SMW_VERSION: ${{ matrix.smw_version }}
+      PHP_VERSION: ${{ matrix.php_version }}
+      AL_VERSION: ${{ matrix.al_version }}
+      DB_TYPE: ${{ matrix.database_type }}
+      DB_IMAGE: ${{ matrix.database_image }}
+
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+                     
+      - name: Update submodules
+        run: git submodule update --init --remote
+
+      - name: Run tests
+        run: make ci
+        if: matrix.coverage == false
+
+      - name: Run tests with coverage
+        run: make ci-coverage
+        if: matrix.coverage == true
+
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage/php/coverage.xml
+        if: matrix.coverage == true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build"]
+	path = build
+	url = https://github.com/gesinn-it-pub/docker-compose-ci.git

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ DB_TYPE?=mysql
 DB_IMAGE?="mysql:8"
 
 # extensions
+SMW_VERSION?=4.2.0
 
 # composer
 # Enables "composer update" inside of extension

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+-include .env
+export
+
+# setup for docker-compose-ci build directory
+# delete "build" directory to update docker-compose-ci
+
+ifeq (,$(wildcard ./build/))
+    $(shell git submodule update --init --remote)
+endif
+
+
+EXTENSION=CreatePage
+
+# docker images
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mysql:8"
+
+# extensions
+
+# composer
+# Enables "composer update" inside of extension
+COMPOSER_EXT?=true
+
+# Enables node.js related tests and "npm install"
+# NODE_JS?=true
+
+
+include build/Makefile
+

--- a/README
+++ b/README
@@ -1,7 +1,0 @@
-These is the readme file for the Create Page extension.
-
-Extension page on mediawiki.org: https://www.mediawiki.org/wiki/Extension:Create_Page
-
-== About ==
-
-Create Page is a MediaWiki extension that allows placing an input that takes the name of a new page into pages.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+[![CI](https://github.com/gesinn-it-pub/CreatePage/actions/workflows/ci.yml/badge.svg)](https://github.com/gesinn-it-pub/CreatePage/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/gesinn-it-pub/CreatePage/graph/badge.svg?token=O6rJr8X0m3)](https://codecov.io/github/gesinn-it-pub/CreatePage)
+
+# CreatePage
+
+Create Page is a MediaWiki extension that allows placing an input that takes the name of a new page into pages.
+
+Extension page on mediawiki.org: https://www.mediawiki.org/wiki/Extension:Create_Page

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/var/www/html/extensions/CreatePage/::"

--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,34 @@
 {
+	"name": "gesinn-it-pub/create-page",
+  	"type": "mediawiki-extension",
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "45.0.0",
+		"mediawiki/mediawiki-phan-config": "0.14.0",
 		"mediawiki/minus-x": "1.1.3",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
 		"php-parallel-lint/php-parallel-lint": "1.4.0"
 	},
 	"scripts": {
-		"fix": [
-			"minus-x fix .",
-			"phpcbf"
-		],
 		"test": [
-			"parallel-lint . --exclude vendor --exclude node_modules",
-			"@phpcs",
-			"minus-x check ."
+			"@analyze",
+			"@phpunit"
 		],
-		"phpcs": "phpcs -sp --cache"
-	},
-	"config": {
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+		"test-coverage": [
+			"@analyze",
+			"@phpunit-coverage"
+		],
+		"analyze": [
+			"@lint",
+			"@phpcs"
+		],
+		"fix": [
+			"@phpcs-fix"
+		],
+		"lint": "parallel-lint . --exclude vendor --exclude node_modules",
+		"phpcs": "phpcs -ps",
+		"phpcs-fix": "phpcbf -p",
+		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox",
+		"phpunit-coverage": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox --coverage-text --coverage-html coverage/php --coverage-clover coverage/php/coverage.xml",
+		"minus-x": "minus-x check ."
 	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="tests">
+            <directory>tests/phpunit</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">includes</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -8,6 +8,7 @@ use SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest;
 
 /**
  * @group SD
+ * @group Database
  * @group SMWExtension
  */
 class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SD\Tests\Integration\JSONScript;
+
+use CreatePageHooks;
+use MediaWiki\MediaWikiServices;
+use SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest;
+
+/**
+ * @group SD
+ * @group SMWExtension
+ */
+class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// register the #createpage parser function
+		$parser = MediaWikiServices::getInstance()->getParser();
+		CreatePageHooks::setupParserFunction( $parser );
+	}
+
+	protected function getTestCaseLocation() {
+		return __DIR__ . '/TestCases';
+	}
+
+	protected function getPermittedSettings() {
+		return array_merge( parent::getPermittedSettings(), [] );
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/display-form-create-page.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/display-form-create-page.json
@@ -1,34 +1,90 @@
 {
-    "description": "Create page form parsing and redirection test",
-    "setup": [
-      {
-        "namespace": "NS_MAIN",
-        "page": "TestPage",
-        "contents": "{{#createpage:||Create this page!}}"
-      }
-    ],
-    "tests": [
-      {
-        "type": "parser",
-        "about": "Test that the create page form is displayed with the correct submit button",
-        "subject": "TestPage",
-        "request-parameters": {},
-        "assert-output": {
-          "to-contain": [
-            "<form action=\"/index.php/Special:CreatePageRedirect\"",
-            "class=\"createpageform\"",
-            "Create this page!"
-          ]
-        }
-      }
-    ],
-    "settings": {
-      "wgLang": "en"
+  "description": "Create page form parsing and redirection test",
+  "setup": [
+    {
+      "namespace": "NS_MAIN",
+      "page": "TestPage",
+      "contents": "{{#createpage:||Create this page!}}"
     },
-    "meta": {
-      "version": "2",
-      "is-incomplete": false,
-      "debug": false
+    {
+      "namespace": "NS_MAIN",
+      "page": "TestPage_course",
+      "contents": "{{#createpage:Course}}"
+    },
+    {
+      "namespace": "NS_MAIN",
+      "page": "TestPage_your_page_name",
+      "contents": "{{#createpage:|Your page name}}"
+    },
+    {
+      "namespace": "NS_MAIN",
+      "page": "TestPage_create_course",
+      "contents": "<p style=\"display:inline\">Enter the name for a new course:</p> {{#createpage:Course||Create course}}"
     }
+  ],
+  "tests": [
+    {
+      "type": "parser",
+      "about": "Test that the create page form is displayed with the correct submit button",
+      "subject": "TestPage",
+      "request-parameters": {},
+      "assert-output": {
+        "to-contain": [
+          "<form action=\"/index.php/Special:CreatePageRedirect\"",
+          "class=\"createpageform\"",
+          "Create this page!"
+        ]
+      }
+    },
+    {
+      "type": "parser",
+      "about": "Test create a page in the Course namespace",
+      "subject": "TestPage_course",
+      "request-parameters": {},
+      "assert-output": {
+        "to-contain": [
+          "<form action=\"/index.php/Special:CreatePageRedirect\"",
+          "class=\"createpageform\"",
+          "<input type=\"hidden\" value=\"Course\" name=\"pagens\" />",
+          "Create page"
+        ]
+      }
+    },
+    {
+      "type": "parser",
+      "about": "Test create a page with a custom name in the form",
+      "subject": "TestPage_your_page_name",
+      "request-parameters": {},
+      "assert-output": {
+        "to-contain": [
+          "<form action=\"/index.php/Special:CreatePageRedirect\"",
+          "class=\"createpageform\"",
+          "<input class=\"pagenameinput\" value=\"Your page name\" name=\"pagename\" />",
+          "Create page"
+        ]
+      }
+    },
+    {
+      "type": "parser",
+      "about": "Test create a course with the correct input field and submit button",
+      "subject": "TestPage_create_course",
+      "request-parameters": {},
+      "assert-output": {
+        "to-contain": [
+          "<p style=\"display:inline\">Enter the name for a new course:</p>",
+          "<form action=\"/index.php/Special:CreatePageRedirect\"",
+          "class=\"createpageform\"",
+          "Create course"
+        ]
+      }
+    }
+  ],
+  "settings": {
+    "wgLang": "en"
+  },
+  "meta": {
+    "version": "2",
+    "is-incomplete": false,
+    "debug": false
   }
-  
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/display-form-create-page.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/display-form-create-page.json
@@ -1,0 +1,34 @@
+{
+    "description": "Create page form parsing and redirection test",
+    "setup": [
+      {
+        "namespace": "NS_MAIN",
+        "page": "TestPage",
+        "contents": "{{#createpage:||Create this page!}}"
+      }
+    ],
+    "tests": [
+      {
+        "type": "parser",
+        "about": "Test that the create page form is displayed with the correct submit button",
+        "subject": "TestPage",
+        "request-parameters": {},
+        "assert-output": {
+          "to-contain": [
+            "<form action=\"/index.php/Special:CreatePageRedirect\"",
+            "class=\"createpageform\"",
+            "Create this page!"
+          ]
+        }
+      }
+    ],
+    "settings": {
+      "wgLang": "en"
+    },
+    "meta": {
+      "version": "2",
+      "is-incomplete": false,
+      "debug": false
+    }
+  }
+  


### PR DESCRIPTION
This PR is related to the issue #1.

This PR contains:

- docker-composer CI added
- sniffs cleared and fixed
- Makefile added
- composer.json updated, phpcs and linting enabled
- cover all usage for `#createpage` parser function with tests
- added GH CI actions - matrix for MW 1.39, MW 1.40 and MW 1.42
- update README.md - add badges for codecov and CI